### PR TITLE
Changed Net:SSH implementation to use pseudo terminal

### DIFF
--- a/lib/do/utils.rb
+++ b/lib/do/utils.rb
@@ -23,13 +23,17 @@ module DO
     #   new_pwd = ask "Tell me the new password of mysql"
     #   run "mysqladmin -u root -p password '#{new_pwd}', :input => old_pwd
     #
-    def ask(question, allow_blank=false)
+    def ask(*args)
+      question = args[0]
+      options = args.last.is_a?(Hash) ? args.pop : {}
       result = ""
+      `stty -echo` if options[:silent]
       loop do
         log("\e[36m%s: \e[0m" % question, false)
         result = $stdin.gets.chomp
-        break if allow_blank || result != ""
+        break if options[:allow_blank] || result != ""
       end
+      `stty echo` && log("\n", false) if options[:silent]
       result
     end
 


### PR DESCRIPTION
On platforms other than OSX, su and sudo need to be run from a terminal (see http://tinyurl.com/44ffr93 for more info). Forcing Net:SSH to request a pseudo terminal gets round this issue.
Passwords are also now not sent to the logger.

The following now both work on remote linux platforms:

run 'ls', :input => password, :as => 'root'
run 'sudo ls', :input => password
