### PR TITLE
Tiny Regex change, and aliasing :on => :webserver for :in => :webserver

### DIFF
--- a/lib/do/server.rb
+++ b/lib/do/server.rb
@@ -87,11 +87,11 @@ module DO
             result << data
             DO_LOGGER.print(data) unless options[:silent]
             if options[:input]
-              match = options[:match] || /password:/i
+              match = options[:match] || /password/i
               if data =~ match
                 options[:input] += "\n" if options[:input][-1] != ?\n
                 channel.send_data(options[:input])
-                DO_LOGGER.puts(options[:input]) unless options[:silent] || data =~ /password:/i
+                DO_LOGGER.puts(options[:input]) unless options[:silent] || data =~ /password/i
               end
             end
           end

--- a/lib/do/tasks.rb
+++ b/lib/do/tasks.rb
@@ -34,7 +34,7 @@ module DO
         :deps      => Array(deps),
         :namespace => @_namespace.to_s,
         :block     => block,
-        :in        => Array(options[:in])
+        :in        => Array(options[:in] ? options[:in] : options[:on])
       }))
       tasks[-1]
     ensure


### PR DESCRIPTION
The password prompt for sudo on newer linux systems is:
`[sudo] password for mickey.mouse:`
The regex /password:/i has had the trailing colon removed to cater for this.

`task :stop_nginx, :on => :webserver`
is clearer than:
`task :stop_nginx, :in => :webserver`

but :in may be clearer in some cases, so now :in and :on are interchangeable
