### PR TITLE
Allow project specific do files

### DIFF
--- a/lib/do/commands.rb
+++ b/lib/do/commands.rb
@@ -52,12 +52,14 @@ module DO
     #   ~/do/*.rake
     #   ./Do
     #   ./Dofile
+    #   ./do/**/*.rake
     #
     # DO_PATH, default is ~/do.
     #
     def recipes
       @_recipes ||= (
         %w[dorc **/*.rake].map { |f| Dir[File.join(DO_PATH, f)] }.flatten +
+        %w[./do/**/*.rake].map { |f| Dir[File.expand_path(f)] }.flatten +
         %w[./Do ./Dofile].map { |f| File.expand_path(f) } <<
         File.expand_path('../common.rb', __FILE__)
       ).reject { |f| !File.exist?(f) }


### PR DESCRIPTION
Allow projects to have their own do files not just one project specific do file which loads in other rake tasks

This I think allows for cleaner, structured rake files and not everything stored in one place

This is useful if one wants to keep project specific files separate from other projects such as configured servers and tasks

This does it for me but feel free to reject this request if it does not meet your project ethos. 
